### PR TITLE
add net profit logic to invest_in_bond

### DIFF
--- a/programs/portfolio_management/src/context/create.rs
+++ b/programs/portfolio_management/src/context/create.rs
@@ -32,7 +32,7 @@ pub struct CreateBond<'info> {
 }
 
 impl<'info> CreateBond<'info>  {
-    pub fn create_bond(&mut self, feed_id: String, bump: &CreateBondBumps) -> Result<()>{
+    pub fn create_bond(&mut self, feed_id: String, bump: &CreateBondBumps) -> Result<()> {
         self.investors_account.feed_id = get_feed_id_from_hex(&feed_id)?;
         self.investors_account.investors_bump = bump.investors_account;
         self.investors_account.vault_bump = bump.vault;

--- a/programs/portfolio_management/src/state/investor.rs
+++ b/programs/portfolio_management/src/state/investor.rs
@@ -23,15 +23,23 @@ impl InvestorsAccount {
         (1) +                                                           // vault_bump
         (1);                                                            // investors_bump
 }
-        //space = 8 + 4 + 32 * MAX_INVESTORS,
 
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
 pub struct Investor {
-    pub identifier:Pubkey,
-    pub amount:u32
+    pub identifier: Pubkey,             // Investor address
+    pub amount: f32,                    // Total amount invested
+    pub net_profit: f32,                // Total net profit, cannot be negative
 }
 
 impl Investor {
     pub const INVESTORS_CAPACITY: usize = 10;
-    pub const MAXIMUM_SIZE: usize = (32) + (4);
+    pub const MAXIMUM_SIZE: usize = (32) + (4) + (4);
+
+    pub fn new(identifier: Pubkey, amount: f32) -> Self {
+        Self {
+            identifier,
+            amount,
+            net_profit: 0_f32,
+        }
+    }
 }


### PR DESCRIPTION
used f32 instead of u64 for the amount and net_profit in investor struct. Conversion logic added to the fund function.

when investing in a bond, the investor needs to be added to the investors vector, or if the investor is already present, the amount needs to be increased.

Issue: #3