### PR TITLE
remove pyth-solana rust sdk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,4 @@ anchor-lang = { version = "0.30.1", git = "https://github.com/coral-xyz/anchor/"
 anchor-spl = { version = "0.30.1", git = "https://github.com/coral-xyz/anchor/", rev = "06527e57c3e59683c36eb0a5c69ee669100b42e5", features = [
     "metadata",
 ] }
-#pyth-solana-receiver-sdk = "0.3.1"
-#pyth-solana-receiver-sdk = { version = "0.3.1", git = "https://github.com/pyth-network/pyth-crosschain" ,rev = "ba27ebfa1f1b497fe35ca7640fe7c0093946d448" }
 wormhole-io = "0.1"

--- a/programs/portfolio_management/Cargo.toml
+++ b/programs/portfolio_management/Cargo.toml
@@ -27,4 +27,3 @@ wormhole-anchor-sdk = { path = "../../modules/wormhole-anchor-sdk", default-feat
   "token-bridge"
 ] }
 wormhole-io = { workspace = true }
-#pyth-solana-receiver-sdk = { workspace = true }

--- a/programs/portfolio_management/src/context/create.rs
+++ b/programs/portfolio_management/src/context/create.rs
@@ -1,4 +1,3 @@
-//use pyth_solana_receiver_sdk::price_update::get_feed_id_from_hex;
 use anchor_lang::prelude::*;
 use anchor_spl::token::{Mint, Token, TokenAccount};
 use crate::state::{Investor, InvestorsAccount};
@@ -33,7 +32,9 @@ pub struct CreateBond<'info> {
 
 impl<'info> CreateBond<'info>  {
     pub fn create_bond(&mut self, feed_id: String, bump: &CreateBondBumps) -> Result<()> {
-        //self.investors_account.feed_id = get_feed_id_from_hex(&feed_id).expect("no");
+
+        // TODO: set feed_id in the investors or use a fixed feed_id for now
+
         self.investors_account.investors_bump = bump.investors_account;
         self.investors_account.vault_bump = bump.vault;
         self.investors_account.investors = Vec::with_capacity(Investor::INVESTORS_CAPACITY);

--- a/programs/portfolio_management/src/context/trade.rs
+++ b/programs/portfolio_management/src/context/trade.rs
@@ -1,13 +1,12 @@
 use crate::state::InvestorsAccount;
 use anchor_lang::prelude::*;
 use anchor_spl::token::{Token, TokenAccount};
-//use pyth_solana_receiver_sdk::price_update::PriceUpdateV2;
+
 
 #[derive(Accounts)]
 pub struct Trade<'info> {
     #[account(mut)]
     pub payer: Signer<'info>,
-    //pub price_update: Account<'info, PriceUpdateV2>,
     #[account(mut)]
     pub investors_account: Account<'info, InvestorsAccount>,
     #[account(
@@ -22,16 +21,9 @@ pub struct Trade<'info> {
 
 impl<'info> Trade<'info> {
     pub fn trade(&mut self, ethereum_price: f64) -> Result<()> {
-        //let price = self.price_update.get_price_no_older_than(
-            //&Clock::get()?,
-            //30,
-            //&self.investors_account.feed_id,
-        //)?;
-        //let price_value = price.price as f64 * 10_f64.powi(price.exponent);
-        //msg!("Price value: {}", price_value);
-        //if price_value > ethereum_price {
-            ////TODO send token inside the vault to the ethereum account
-        //}
+
+        // TODO: implement trading logic between chains using token bridge
+
         Ok(())
     }
 }


### PR DESCRIPTION
did not remove ts sdk since we use it to retrieve feed ids for creating a bond from id