### PR TITLE
Fix/use u64 inside investor data account

### DIFF
--- a/programs/portfolio_management/src/context/fund.rs
+++ b/programs/portfolio_management/src/context/fund.rs
@@ -51,14 +51,11 @@ impl<'info> Fund<'info> {
 
         transfer(cpi_ctx, amount)?;
 
-        /// TODO: change this to u32 or u64 type instead
-        let amount_as_f32 = amount as f32 / 10_u32.pow(6_u32) as f32;
-
         let investors: &mut Vec<Investor> = &mut self.investors_account.investors;
         if let Some(investor) = investors.iter_mut().find(|investor| investor.identifier == to_account.key()) {
-            investor.amount += amount_as_f32;
+            investor.amount += amount;
         } else {
-            self.investors_account.investors.push(Investor::new(to_account.key(), amount_as_f32))
+            self.investors_account.investors.push(Investor::new(to_account.key(), amount))
         }
 
         Ok(())

--- a/programs/portfolio_management/src/state/investor.rs
+++ b/programs/portfolio_management/src/state/investor.rs
@@ -31,18 +31,18 @@ impl InvestorsAccount {
 #[derive(AnchorSerialize, AnchorDeserialize, Clone)]
 pub struct Investor {
     pub identifier: Pubkey,             // Investor address
-    pub amount: f32,                    // Total amount invested
-    pub net_profit: f32,                // Total net profit, cannot be negative
+    pub amount: u64,                    // Total amount invested
+    pub net_profit: u64,                // Total net profit, cannot be negative
 }
 
 impl Investor {
-    pub const MAXIMUM_SIZE: usize = (32) + (4) + (4);
+    pub const MAXIMUM_SIZE: usize = (32) + (8) + (8);
 
-    pub fn new(identifier: Pubkey, amount: f32) -> Self {
+    pub fn new(identifier: Pubkey, amount: u64) -> Self {
         Self {
             identifier,
             amount,
-            net_profit: 0_f32,
+            net_profit: 0 as u64,
         }
     }
 }
@@ -56,7 +56,7 @@ mod test {
     fn test_investor_mem_size() {
         assert_eq!(
             Investor::MAXIMUM_SIZE,
-            size_of::<Pubkey>() + size_of::<f32>() + size_of::<f32>()
+            size_of::<Pubkey>() + size_of::<u64>() + size_of::<u64>()
         );
     }
 


### PR DESCRIPTION
closes #6 

now we use `u64` directly inside investor data account. 